### PR TITLE
Chapter08: eec241lc512_remove returns void

### DIFF
--- a/Chapter08/ee24lc512.c
+++ b/Chapter08/ee24lc512.c
@@ -377,7 +377,7 @@ fail:
     return err;
 }
 
-static int ee24lc512_remove(struct i2c_client *client)
+static void ee24lc512_remove(struct i2c_client *client)
 {
     struct eep_dev *eeprom = i2c_get_clientdata(client);
 
@@ -389,7 +389,6 @@ static int ee24lc512_remove(struct i2c_client *client)
         kfree(eeprom);
     mutex_unlock(&device_list_lock);
 
-    return 0;
 }
 
 static const struct i2c_device_id ee24lc512_id[] = {


### PR DESCRIPTION
Hi, 

Issue #6 

When building Chapter08/ using make, there's a type mismatch for the ee24lc512_remove function as shown below:

![image](https://github.com/PacktPublishing/Linux-Device-Driver-Development-Second-Edition/assets/39401808/9791b7f2-5d79-4239-af92-d2aedbdbbb0a)

The .remove method in the definition of ee24lc512_i2c_driver points to ee24lc512_remove, which is defined as 

![image](https://github.com/PacktPublishing/Linux-Device-Driver-Development-Second-Edition/assets/39401808/2b2161f1-102e-4e36-be89-e4523897ee1d)

As you see, it's defined with return integer, but according to the prototype in <linux/i2c.h> it should return void as shown below

![image](https://github.com/PacktPublishing/Linux-Device-Driver-Development-Second-Edition/assets/39401808/1c2d31f2-d918-4fe2-abef-4ae9dfe84eea)


